### PR TITLE
Added functionality to register extra readers

### DIFF
--- a/GCR/AlphaQGalaxyCatalog.py
+++ b/GCR/AlphaQGalaxyCatalog.py
@@ -6,7 +6,7 @@ import os
 import numpy as np
 import h5py
 from astropy.cosmology import FlatLambdaCDM
-from .BaseGalaxyCatalog import BaseGalaxyCatalog
+from . import register_reader, BaseGalaxyCatalog
 
 __all__ = ['AlphaQGalaxyCatalog']
 
@@ -61,3 +61,6 @@ class AlphaQGalaxyCatalog(BaseGalaxyCatalog):
     @staticmethod
     def _fetch_native_quantity(dataset, native_quantity):
         return dataset[native_quantity].value
+
+# Registers the reader
+register_reader(AlphaQGalaxyCatalog)

--- a/GCR/BuzzardGalaxyCatalog.py
+++ b/GCR/BuzzardGalaxyCatalog.py
@@ -6,7 +6,7 @@ import os
 import numpy as np
 from astropy.io import fits
 from astropy.cosmology import FlatLambdaCDM
-from .BaseGalaxyCatalog import BaseGalaxyCatalog
+from . import register_reader, BaseGalaxyCatalog
 
 __all__ = ['BuzzardGalaxyCatalog']
 
@@ -143,3 +143,6 @@ class BuzzardGalaxyCatalog(BaseGalaxyCatalog):
         if len(native_quantity) == 3:
             data = data[:,native_quantity[2]]
         return data
+
+# Registers the reader
+register_reader(BuzzardGalaxyCatalog)

--- a/GCR/GalacticusGalaxyCatalog.py
+++ b/GCR/GalacticusGalaxyCatalog.py
@@ -6,7 +6,7 @@ import os
 import numpy as np
 import h5py
 from astropy.cosmology import FlatLambdaCDM
-from .BaseGalaxyCatalog import BaseGalaxyCatalog
+from . import register_reader, BaseGalaxyCatalog
 
 __all__ = ['GalacticusGalaxyCatalog']
 
@@ -61,3 +61,6 @@ class GalacticusGalaxyCatalog(BaseGalaxyCatalog):
             data.fill(dataset.attrs['z'])
             return data
         return dataset[native_quantity].value
+
+# Registers the reader
+register_reader(GalacticusGalaxyCatalog)

--- a/GCR/__init__.py
+++ b/GCR/__init__.py
@@ -1,9 +1,22 @@
+import yaml
 from .BaseGalaxyCatalog import BaseGalaxyCatalog
+
+_registered_readers = {}
+
+def register_reader(subclass):
+    """
+    Registers a new galaxy catalog type with the loading utility.
+
+    Parameters
+    ----------
+    subclass: subclass of BaseGalaxyCatalog
+    """
+    assert issubclass(subclass, BaseGalaxyCatalog) , "Provided class is not a subclass of BaseGalaxyCatalog"
+    _registered_readers[subclass.__name__] = subclass
+
 from .GalacticusGalaxyCatalog import GalacticusGalaxyCatalog
 from .BuzzardGalaxyCatalog import BuzzardGalaxyCatalog
 from .AlphaQGalaxyCatalog import AlphaQGalaxyCatalog
-
-import yaml
 
 def _load_yaml_config(yaml_config_file):
     with open(yaml_config_file) as f:
@@ -28,4 +41,4 @@ def load_catalog(yaml_config_file, config_overwrite=None):
     config = _load_yaml_config(yaml_config_file)
     if config_overwrite:
         config.update(config_overwrite)
-    return globals()[config['subclass_name']](**config)
+    return _registered_readers[config['subclass_name']](**config)


### PR DESCRIPTION
This pull request aims at addressing issue #1 by adding a mechanism to register readers both manually and automatically. 

I have added a `register_reader()` function, and added it after each reader definition so that it is automatically called when the reader is imported.

Once registered, that reader can be loaded with the yaml catalog loading function.